### PR TITLE
update development instructions to webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Using Docker:
 
 1. Clone the repository and `cd` to it
 1. make sure you have [npm](https://www.npmjs.com/) installed
-1. install project dependencies: `npm install .`
+1. install project dependencies: `yarn install --pure-lockfile`
 1. Start the "watch" task: `npm run watch`
 1. Run a local Grafana instance with the development version of the plugin: `docker run -p 3000:3000 -d --name grafana-plugin-dev --volume $(pwd)/dist:/var/lib/grafana/plugins/clock-panel grafana/grafana`
 1. Check the logs to see that Grafana has started up: `docker logs -f grafana-plugin-dev`

--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ Show the time in another office or show a countdown to an important event.
 Using Docker:
 
 1. Clone the repository and `cd` to it
+1. make sure you have [npm](https://www.npmjs.com/) installed
+1. install project dependencies: `npm install .`
+1. Start the "watch" task: `npm run watch`
 1. Run a local Grafana instance with the development version of the plugin: `docker run -p 3000:3000 -d --name grafana-plugin-dev --volume $(pwd)/dist:/var/lib/grafana/plugins/clock-panel grafana/grafana`
 1. Check the logs to see that Grafana has started up: `docker logs -f grafana-plugin-dev`
-1. Make sure you have https://github.com/gruntjs/grunt-cli installed
-1. Start the "watch" task: `grunt watch`
 1. Open Grafana at http://localhost:3000/
 1. Log in with username "admin" and password "admin"
 1. Create new dashboard and add the plugin

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Show the time in another office or show a countdown to an important event.
 Using Docker:
 
 1. Clone the repository and `cd` to it
-1. make sure you have [npm](https://www.npmjs.com/) installed
+1. make sure you have [yarn]( https://yarnpkg.com/) installed
 1. install project dependencies: `yarn install --pure-lockfile`
 1. Start the "watch" task: `npm run watch`
 1. Run a local Grafana instance with the development version of the plugin: `docker run -p 3000:3000 -d --name grafana-plugin-dev --volume $(pwd)/dist:/var/lib/grafana/plugins/clock-panel grafana/grafana`

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Using Docker:
 1. Clone the repository and `cd` to it
 1. make sure you have [yarn]( https://yarnpkg.com/) installed
 1. install project dependencies: `yarn install --pure-lockfile`
-1. Start the "watch" task: `npm run watch`
+1. Start the "watch" task: `yarn watch`
 1. Run a local Grafana instance with the development version of the plugin: `docker run -p 3000:3000 -d --name grafana-plugin-dev --volume $(pwd)/dist:/var/lib/grafana/plugins/clock-panel grafana/grafana`
 1. Check the logs to see that Grafana has started up: `docker logs -f grafana-plugin-dev`
 1. Open Grafana at http://localhost:3000/


### PR DESCRIPTION
closes #34

I also moved the project setup steps to before the docker startup, because otherwise you need to restart the grafana instance after `/dist` gets built to load the "new" plugin.