### PR TITLE
Allow to define the locale for date-formats, renewed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Show the time in another office or show a countdown to an important event.
 
   This timezones are supplied by the moment timezone library. Timezone can be set or left to default. Default is moment's guess (whatever that is on your computer). Timezone is also used to calculate countdown deadline in countdown mode.
 
+- **Locale**:
+
+  Locales for date-formatting are supplied by the moment library. The locale can be set or left to default. Default is moment's guess.
+
 - **Countdown Deadline**:
 
   Used in conjunction with the mode being set to countdown. Choose a date and time to count down to.

--- a/src/ClockPanel.tsx
+++ b/src/ClockPanel.tsx
@@ -123,7 +123,6 @@ export class ClockPanel extends PureComponent<Props, State> {
       font-size: ${timezoneSettings.fontSize};
       font-weight: ${timezoneSettings.fontWeight};
       line-height: 1.4;
-      text-align: center;
     `;
 
     let zone = this.props.options.timezone || '';
@@ -198,6 +197,7 @@ export class ClockPanel extends PureComponent<Props, State> {
       justify-content: center;
       flex-direction: column;
       background-color: ${bgColor ?? ''};
+      text-align: center;
     `;
 
     return (

--- a/src/ClockPanel.tsx
+++ b/src/ClockPanel.tsx
@@ -167,7 +167,7 @@ export class ClockPanel extends PureComponent<Props, State> {
       font-weight: ${dateSettings.fontWeight};
     `;
 
-    const disp = now.format(dateSettings.dateFormat);
+    const disp = now.locale(dateSettings.locale || '').format(dateSettings.dateFormat);
     return (
       <span>
         <h3 className={clazz}>{disp}</h3>

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -255,6 +255,16 @@ function addDateFormat(builder: PanelOptionsEditorBuilder<ClockOptions>) {
     })
     .addTextInput({
       category,
+      path: 'dateSettings.locale',
+      name: 'Locale',
+      settings: {
+        placeholder: 'Enter locale: de, fr, es, ... (default: en)',
+      },
+      defaultValue: '',
+      showIf: s => s.dateSettings?.showDate,
+    })
+    .addTextInput({
+      category,
       path: 'dateSettings.fontSize',
       name: 'Font size',
       settings: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ interface CountdownSettings {
 interface DateSettings {
   showDate: boolean;
   dateFormat: string;
+  locale: string;
   fontSize: string;
   fontWeight: FontWeight;
 }


### PR DESCRIPTION
Renewed PR #65  after the change in the main-repo to react. Same functionality: allow to define the locale in the date-Options