### PR TITLE
Chaging import to moment-timezone to avoid error on amg

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,11 @@
     "@grafana/toolkit": "7.4.0",
     "@grafana/runtime": "7.4.0",
     "@types/lodash": "latest",
-    "@types/moment-timezone": "^0.5.12",
-    "lodash": "latest",
-    "moment": "2.24.0"
+    "lodash": "latest"
   },
   "dependencies": {
-    "moment-timezone": "0.5.28"
+    "moment": "2.29.2",
+    "moment-timezone": "0.5.34"
   },
   "volta": {
     "node": "14.17.6",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "@grafana/toolkit": "7.4.0",
     "@grafana/runtime": "7.4.0",
     "@types/lodash": "latest",
-    "lodash": "latest"
+    "lodash": "latest",
+    "moment": "2.29.2"
   },
   "dependencies": {
-    "moment": "2.29.2",
     "moment-timezone": "0.5.34"
   },
   "volta": {

--- a/src/ClockPanel.tsx
+++ b/src/ClockPanel.tsx
@@ -5,7 +5,7 @@ import { ClockOptions, ClockType, ZoneFormat, ClockMode, ClockRefresh } from './
 import { css } from 'emotion';
 
 // eslint-disable-next-line
-import moment, { Moment } from 'moment';
+import moment, { Moment } from 'moment-timezone';
 import './external/moment-duration-format';
 
 interface Props extends Themeable, PanelProps<ClockOptions> {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2073,13 +2073,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
-"@types/moment-timezone@^0.5.12":
-  version "0.5.30"
-  resolved "https://registry.yarnpkg.com/@types/moment-timezone/-/moment-timezone-0.5.30.tgz#340ed45fe3e715f4a011f5cfceb7cb52aad46fc7"
-  integrity sha512-aDVfCsjYnAQaV/E9Qc24C5Njx1CoDjXsEgkxtp9NyXDpYu4CCbmclb6QhWloS9UTU/8YROUEEdEkWI0D7DxnKg==
-  dependencies:
-    moment-timezone "*"
-
 "@types/node@*":
   version "16.9.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.1.tgz#0611b37db4246c937feef529ddcc018cf8e35708"
@@ -8510,17 +8503,10 @@ mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-moment-timezone@*:
-  version "0.5.33"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
-  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
-  dependencies:
-    moment ">= 2.9.0"
-
-moment-timezone@0.5.28:
-  version "0.5.28"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.28.tgz#f093d789d091ed7b055d82aa81a82467f72e4338"
-  integrity sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==
+moment-timezone@0.5.34:
+  version "0.5.34"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
+  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
   dependencies:
     moment ">= 2.9.0"
 
@@ -8533,6 +8519,11 @@ moment@2.29.1, moment@2.x, "moment@>= 2.9.0":
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
+moment@2.29.2:
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
+  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
 
 monaco-editor@*:
   version "0.27.0"


### PR DESCRIPTION
* Bumping versions of moment and moment-timezone to the same ones as used at grafana/grafana project
* Changing import to moment-timezone as is used on grafana project
This PR intends to fix this issue https://github.com/grafana/support-escalations/issues/2633