### PR TITLE
Timezones: Add template variable support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [2.1.0]
+- Added support to set timezone from template variable
+
 ## [2.0.0]
 - Prevent clock panel from crashing Grafana 9.x.x
 - Drop support for Grafana 7.x.x

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@grafana/ui": "8.0.0",
     "@types/lodash": "latest",
     "lodash": "latest",
-    "moment": "2.29.2"
+    "moment": "2.29.2",
+    "tslib": "2.3.1"
   },
   "dependencies": {
     "moment-timezone": "0.5.34"

--- a/src/ClockPanel.tsx
+++ b/src/ClockPanel.tsx
@@ -7,6 +7,7 @@ import { css } from '@emotion/css';
 // eslint-disable-next-line
 import moment, { Moment } from 'moment-timezone';
 import './external/moment-duration-format';
+import { getTemplateSrv } from '@grafana/runtime';
 
 interface Props extends Themeable2, PanelProps<ClockOptions> {}
 interface State {
@@ -96,6 +97,8 @@ class UnthemedClockPanel extends PureComponent<Props, State> {
   getTZ(tz?: string): Moment {
     if (!tz) {
       tz = (moment as any).tz.guess();
+    } else {
+      tz = getTemplateSrv().replace(tz);
     }
     return (moment() as any).tz(tz);
   }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,8 +1,9 @@
-import { PanelOptionsEditorBuilder, dateTime } from '@grafana/data';
+import { PanelOptionsEditorBuilder, dateTime, SelectableValue } from '@grafana/data';
 
 import { ClockOptions, ClockMode, ClockType, FontWeight, ZoneFormat, ClockRefresh } from './types';
 import { getTimeZoneNames } from './ClockPanel';
 import { ColorEditor } from './ColorEditor';
+import { getTemplateSrv } from '@grafana/runtime';
 
 export const optionsBuilder = (builder: PanelOptionsEditorBuilder<ClockOptions>) => {
   // Global options
@@ -173,6 +174,20 @@ function addTimeFormat(builder: PanelOptionsEditorBuilder<ClockOptions>) {
     });
 }
 
+function getVariableOptions() {
+  return getTemplateSrv()
+    .getVariables()
+    .map((t) => {
+      const value = '${' + t.name + '}';
+      const info: SelectableValue<string> = {
+        label: value,
+        value,
+        icon: 'arrow-right',
+      };
+      return info;
+    });
+}
+
 //---------------------------------------------------------------------
 // TIMEZONE
 //---------------------------------------------------------------------
@@ -191,6 +206,13 @@ function addTimeZone(builder: PanelOptionsEditorBuilder<ClockOptions>) {
       name: 'Timezone',
       settings: {
         options: timezones,
+        getOptions: async () => {
+          const opts = getVariableOptions();
+          if (opts.length) {
+            return [...opts, ...timezones];
+          }
+          return timezones;
+        },
       },
       defaultValue: '',
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -11799,6 +11799,11 @@ tslib@2.2.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
+tslib@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"


### PR DESCRIPTION
If template variables exist, user can select them for timezone. If a correct string exists, it will use that to update timezone, otherwise, it will default to local time.

![image](https://user-images.githubusercontent.com/60050885/171961322-b67eb1bb-db97-4537-9d95-44e3bd2b169d.png)
