### PR TITLE
Adding flex flow to wrap when height is reduced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [2.1.2]
+- Improving wrapping of the panel elements to be more responsive to different panel sizes https://github.com/grafana/clock-panel/pull/117
+- Fixing a placeholder for the font size field https://github.com/grafana/clock-panel/pull/116
+- 
 ## [2.1.1]
 - Migrate to create-plugin instead of toolkit
 - Small typo fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clock-panel",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Clock Panel Plugin for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/provisioning/dashboards/dashboard.json
+++ b/provisioning/dashboards/dashboard.json
@@ -24,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 9,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -862,6 +861,54 @@
       ],
       "title": "Template variable: countup since ${__from:date}",
       "type": "grafana-clock-panel"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 5,
+        "x": 0,
+        "y": 17
+      },
+      "id": 18,
+      "options": {
+        "bgColor": "",
+        "clockType": "24 hour",
+        "countdownSettings": {
+          "endCountdownTime": "2022-12-31T00:28:17+01:00",
+          "endText": "00:00:00"
+        },
+        "countupSettings": {
+          "beginCountupTime": "2022-12-31T00:28:17+01:00",
+          "beginText": "00:00:00"
+        },
+        "dateSettings": {
+          "dateFormat": "YYYY-MM-DD",
+          "fontSize": "12px",
+          "fontWeight": "normal",
+          "locale": "",
+          "showDate": true
+        },
+        "mode": "time",
+        "refresh": "sec",
+        "timeSettings": {
+          "fontSize": "12px",
+          "fontWeight": "normal"
+        },
+        "timezone": "",
+        "timezoneSettings": {
+          "fontSize": "12px",
+          "fontWeight": "normal",
+          "showTimezone": true,
+          "zoneFormat": "offsetAbbv"
+        }
+      },
+      "pluginVersion": "2.1.1",
+      "title": "Should switch to one line based on height",
+      "type": "grafana-clock-panel"
     }
   ],
   "schemaVersion": 37,
@@ -878,6 +925,6 @@
   "timezone": "",
   "title": "Testing",
   "uid": "bJryn4dVz",
-  "version": 9,
+  "version": 1,
   "weekStart": ""
 }

--- a/src/ClockPanel.tsx
+++ b/src/ClockPanel.tsx
@@ -305,6 +305,7 @@ class UnthemedClockPanel extends PureComponent<Props, State> {
       align-items: center;
       justify-content: center;
       flex-direction: column;
+      flex-flow: column wrap;
       text-align: center;
       background-color: ${!bgColor ? theme.colors.background.primary : theme.v1.visualization.getColorByName(bgColor)};
     `;

--- a/src/ClockPanel.tsx
+++ b/src/ClockPanel.tsx
@@ -303,8 +303,7 @@ class UnthemedClockPanel extends PureComponent<Props, State> {
     const className = css`
       display: flex;
       align-items: center;
-      justify-content: center;
-      flex-direction: column;
+      justify-content: center;      
       flex-flow: column wrap;
       text-align: center;
       background-color: ${!bgColor ? theme.colors.background.primary : theme.v1.visualization.getColorByName(bgColor)};


### PR DESCRIPTION
Based off https://github.com/grafana/grafana/discussions/60568

Adding `flex-flow: column wrap;` which should lead to the same behaviour as before when there is enough height in the panel and to switching to inline when the height is reduced.

![SCR-20221230-pqa](https://user-images.githubusercontent.com/580672/210097507-6c56873e-61e7-4aa5-9b75-05b146bc614c.png)
