### PR TITLE
Chore: Bump moment and moment-timezone packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "identity-obj-proxy": "3.0.0",
     "jest": "27.5.0",
     "lodash": "latest",
-    "moment": "2.29.2",
+    "moment": "2.29.4",
     "prettier": "^2.5.0",
     "replace-in-file-webpack-plugin": "^1.0.6",
     "sass": "1.56.1",
@@ -76,7 +76,7 @@
     "@grafana/data": "9.1.2",
     "@grafana/runtime": "9.1.2",
     "@grafana/ui": "9.1.2",
-    "moment-timezone": "0.5.34",
+    "moment-timezone": "0.5.38",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clock-panel",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Clock Panel Plugin for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7987,10 +7987,12 @@ moment-timezone@0.5.34:
   dependencies:
     moment ">= 2.9.0"
 
-moment@2.29.2:
-  version "2.29.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
-  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
+moment-timezone@0.5.38:
+  version "0.5.38"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.38.tgz#9674a5397b8be7c13de820fd387d8afa0f725aad"
+  integrity sha512-nMIrzGah4+oYZPflDvLZUgoVUO4fvAqHstvG3xAUnMolWncuAiLDWNnJZj6EwJGMGfb1ZcuTFE6GI3hNOVWI/Q==
+  dependencies:
+    moment ">= 2.9.0"
 
 moment@2.29.4:
   version "2.29.4"


### PR DESCRIPTION
This PR updates the moment and moment-timezone packages to match the current versions found in Grafana core.

- moment@2.29.2 -> moment@2.29.4
- moment-timezone@0.5.34 -> moment-timezone@0.5.38

Patch bumps clock-panel plugin to 2.1.3

Built and tested against the docker dev env and all seems well...

![image](https://user-images.githubusercontent.com/73201/222763888-fa5f1d0f-6a17-42ce-9d33-18d204ca4f14.png)
