### PR TITLE
Chore: Resolve moment and moment-timezone to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,5 +79,9 @@
     "moment-timezone": "0.5.38",
     "react": "17.0.2",
     "react-dom": "17.0.2"
+  },
+  "resolutions": {
+    "moment": "2.29.4",
+    "moment-timezone": "0.5.38"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7980,34 +7980,17 @@ mocha@10.0.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
-moment-timezone@0.5.34:
-  version "0.5.34"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
-  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
-  dependencies:
-    moment ">= 2.9.0"
-
-moment-timezone@0.5.38:
+moment-timezone@0.5.34, moment-timezone@0.5.38:
   version "0.5.38"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.38.tgz#9674a5397b8be7c13de820fd387d8afa0f725aad"
   integrity sha512-nMIrzGah4+oYZPflDvLZUgoVUO4fvAqHstvG3xAUnMolWncuAiLDWNnJZj6EwJGMGfb1ZcuTFE6GI3hNOVWI/Q==
   dependencies:
     moment ">= 2.9.0"
 
-moment@2.29.4:
+moment@2.29.4, moment@2.x, "moment@>= 2.9.0":
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
-
-moment@2.x:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
-  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
-
-"moment@>= 2.9.0":
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 monaco-editor@^0.31.1:
   version "0.31.1"


### PR DESCRIPTION
This PR removes older versions of moment and moment-timezone from the yarn.lock file by way of resolutions.

Note that neither `@grafana/ui`, `@grafana/data`, or `moment` are bundled in a plugin. The version of `moment` that is used at runtime comes from the Grafana servers dependencies via SystemJS.

`moment-timezone` however will be bundled in this plugin. Due to yarn hoisting strategies and the fact this is a direct dependency of the plugin the version bundled is `0.5.38`. You can see this in the `dist/module.js.map`

<img width="1111" alt="dist/module.js.map" src="https://user-images.githubusercontent.com/73201/226292604-785b0c8d-8850-4c91-ab6c-e6b8441fe0cf.png">

With all that said I don't think this PR needs to release a new version of the plugin as all its doing is silencing code scanners.
