### PR TITLE
Add option for monofont

### DIFF
--- a/src/ClockPanel.tsx
+++ b/src/ClockPanel.tsx
@@ -26,12 +26,13 @@ export function ClockPanel(props: Props) {
       align-items: center;
       justify-content: center;
       flex-flow: column wrap;
+      font-family: ${options.fontMono ? 'monospace' : ''};
       text-align: center;
       background-color: ${!options.bgColor
         ? theme.colors.background.primary
         : theme.v1.visualization.getColorByName(options.bgColor)};
     `;
-  }, [options.bgColor, theme]);
+  }, [options.bgColor, options.fontMono, theme]);
 
   // Clock refresh only on dashboard refresh
   useEffect(() => {

--- a/src/ClockPanel.tsx
+++ b/src/ClockPanel.tsx
@@ -30,7 +30,7 @@ export function ClockPanel(props: Props) {
       text-align: center;
       background-color: ${!options.bgColor
         ? theme.colors.background.primary
-        : theme.v1.visualization.getColorByName(options.bgColor)};
+        : theme.visualization.getColorByName(options.bgColor)};
     `;
   }, [options.bgColor, options.fontMono, theme]);
 

--- a/src/ColorEditor.tsx
+++ b/src/ColorEditor.tsx
@@ -26,7 +26,7 @@ export function ColorEditor(props: any) {
 
   return (
     <div>
-      <Input type="text" value={props.value || 'Pick Color'} prefix={prefix} suffix={suffix} />
+      <Input type="text" value={props.value || 'Pick Color'} prefix={prefix} suffix={suffix} readOnly={true} />
     </div>
   );
 }

--- a/src/components/RenderDate.tsx
+++ b/src/components/RenderDate.tsx
@@ -10,9 +10,10 @@ export function RenderDate({ options, now }: { options: ClockOptions; now: Momen
     return css`
       font-size: ${dateSettings.fontSize};
       font-weight: ${dateSettings.fontWeight};
+      font-family: ${options.fontMono ? 'monospace' : ''};
       margin: 0;
     `;
-  }, [dateSettings]);
+  }, [dateSettings.fontSize, dateSettings.fontWeight, options.fontMono]);
 
   const display = now.locale(dateSettings.locale || '').format(dateSettings.dateFormat);
 

--- a/src/components/RenderTime.tsx
+++ b/src/components/RenderTime.tsx
@@ -153,10 +153,11 @@ export function RenderTime({
   const className = useMemo(() => {
     return css`
       font-size: ${timeSettings.fontSize};
+      font-family: ${options.fontMono ? 'monospace' : ''};
       font-weight: ${timeSettings.fontWeight};
       margin: 0;
     `;
-  }, [timeSettings]);
+  }, [options.fontMono, timeSettings.fontSize, timeSettings.fontWeight]);
 
   let display = '';
   switch (mode) {

--- a/src/components/RenderZone.tsx
+++ b/src/components/RenderZone.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { Moment } from 'moment-timezone';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ClockOptions, ZoneFormat } from 'types';
 import { getMoment } from 'utils';
 
@@ -8,12 +8,15 @@ export function RenderZone({ options, now }: { options: ClockOptions; now: Momen
   const { timezoneSettings } = options;
   const { zoneFormat } = timezoneSettings;
 
-  const className = css`
-    font-size: ${timezoneSettings.fontSize};
-    font-weight: ${timezoneSettings.fontWeight};
-    line-height: 1.4;
-    margin: 0;
-  `;
+  const className = useMemo(() => {
+    return css`
+      font-size: ${timezoneSettings.fontSize};
+      font-weight: ${timezoneSettings.fontWeight};
+      font-family: ${options.fontMono ? 'monospace' : ''};
+      line-height: 1.4;
+      margin: 0;
+    `;
+  }, [options.fontMono, timezoneSettings.fontSize, timezoneSettings.fontWeight]);
 
   let zone = options.timezone || '';
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -37,6 +37,11 @@ export const optionsBuilder = (builder: PanelOptionsEditorBuilder<ClockOptions>)
       name: 'Background Color',
       editor: ColorEditor,
       defaultValue: '',
+    })
+    .addBooleanSwitch({
+      path: 'fontMono',
+      name: 'Font monospace',
+      defaultValue: false,
     });
 
   addCountdown(builder);

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface ClockOptions {
   clockType: ClockType;
   timezone?: string;
   bgColor?: string;
+  fontMono?: boolean;
   countdownSettings: CountdownSettings;
   countupSettings: CountupSettings;
   dateSettings: DateSettings;


### PR DESCRIPTION
Adds a new option to show the font in monospace.
![Peek 2023-09-01 15-28](https://github.com/grafana/clock-panel/assets/227916/7963b96a-b0ee-496d-a810-6a1787152b52)
