### PR TITLE
Add option to render using the dashboard timezone

### DIFF
--- a/src/ClockPanel.tsx
+++ b/src/ClockPanel.tsx
@@ -18,7 +18,7 @@ export function ClockPanel(props: Props) {
   const { options, width, height } = props;
   const theme = useTheme2();
   const { timezone: optionsTimezone, dateSettings, timezoneSettings } = options;
-  // notice the upercase Z.
+  // notice the uppercase Z.
   const { timeZone: dashboardTimezone } = props;
   const timezoneToUse = optionsTimezone === 'dashboard' ? dashboardTimezone : optionsTimezone ?? '';
   const [now, setNow] = useState<Moment>(getMoment(timezoneToUse));

--- a/src/components/RenderTime.tsx
+++ b/src/components/RenderTime.tsx
@@ -143,9 +143,11 @@ function getTimeFormat(clockType: ClockType, timeSettings: TimeSettings): string
 export function RenderTime({
   now,
   replaceVariables,
+  timezone,
   options,
 }: {
   now: Moment;
+  timezone: ClockOptions['timezone'];
   replaceVariables: PanelProps['replaceVariables'];
   options: ClockOptions;
 }) {
@@ -164,7 +166,7 @@ export function RenderTime({
     case ClockMode.countdown:
       display = getCountdownText({
         countdownSettings: options.countdownSettings,
-        timezone: options.timezone,
+        timezone: timezone,
         replaceVariables,
         now,
       });
@@ -172,7 +174,7 @@ export function RenderTime({
     case ClockMode.countup:
       display = getCountupText({
         countupSettings: options.countupSettings,
-        timezone: options.timezone,
+        timezone: timezone,
         replaceVariables,
         now,
       });

--- a/src/components/RenderZone.tsx
+++ b/src/components/RenderZone.tsx
@@ -4,7 +4,7 @@ import React, { useMemo } from 'react';
 import { ClockOptions, ZoneFormat } from 'types';
 import { getMoment } from 'utils';
 
-export function RenderZone({ options, now }: { options: ClockOptions; now: Moment }) {
+export function RenderZone({ options, now, timezone }: { options: ClockOptions; now: Moment; timezone: string }) {
   const { timezoneSettings } = options;
   const { zoneFormat } = timezoneSettings;
 
@@ -18,7 +18,7 @@ export function RenderZone({ options, now }: { options: ClockOptions; now: Momen
     `;
   }, [options.fontMono, timezoneSettings.fontSize, timezoneSettings.fontWeight]);
 
-  let zone = options.timezone || '';
+  let zone = timezone;
 
   switch (zoneFormat) {
     case ZoneFormat.offsetAbbv:

--- a/src/options.ts
+++ b/src/options.ts
@@ -200,7 +200,7 @@ function addTimeZone(builder: PanelOptionsEditorBuilder<ClockOptions>) {
   const category = ['Timezone'];
 
   const timezones = [
-    { label: 'Default (Browser)', value: '' },
+    { label: 'Browser Time', value: '' },
     { label: 'Same as Dashboard', value: 'dashboard' },
     ...getTimeZoneNames().map((n) => {
       return { label: n, value: n };

--- a/src/options.ts
+++ b/src/options.ts
@@ -199,10 +199,13 @@ function getVariableOptions() {
 function addTimeZone(builder: PanelOptionsEditorBuilder<ClockOptions>) {
   const category = ['Timezone'];
 
-  const timezones = getTimeZoneNames().map((n) => {
-    return { label: n, value: n };
-  });
-  timezones.unshift({ label: 'Default', value: '' });
+  const timezones = [
+    { label: 'Default (Browser)', value: '' },
+    { label: 'Same as Dashboard', value: 'dashboard' },
+    ...getTimeZoneNames().map((n) => {
+      return { label: n, value: n };
+    }),
+  ];
 
   builder
     .addSelect({


### PR DESCRIPTION
Adds a new option in the panel to use the same timezone as the dashboard 
![image](https://github.com/grafana/clock-panel/assets/227916/bc2d8226-ba7e-428a-a125-485cbe17a2f8)


The dashboard timezone is the same as the browser by default but can be changed in the time range selection

![image](https://github.com/grafana/clock-panel/assets/227916/d3e83301-25f3-4a51-a99f-0f1e19bee68b)

1. Change the time range
2. Change time settings
3. Select a different time zone

With this option selected, not only the time will display the dashboard timezone but it'll be also take in consideration for count ups and count downs.

Closes https://github.com/grafana/clock-panel/issues/135
