### PR TITLE
Enhance clock panel migration to set grafana datasource as default when on queries are in use

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -1,24 +1,16 @@
 {
-    "ignorePaths": [
-        "node_modules/**",
-        "dist/**",
-        "src/external/**",
-        "provisioning/**",
-        "package.json"
-    ],
-    "words": [
-        "gdev",
-        "grafana",
-        "datasource",
-        "datasources",
-        "rgba",
-        "countup",
-        "Themeable",
-        "Unthemed",
-        "testdata",
-        "testid"
-    ],
-    "ignoreRegExpList": [
-        "@[\\w]+"
-    ]
+  "ignorePaths": ["node_modules/**", "dist/**", "src/external/**", "src/**/*.tsx", "provisioning/**", "package.json"],
+  "words": [
+    "gdev",
+    "grafana",
+    "datasource",
+    "datasources",
+    "rgba",
+    "countup",
+    "Themeable",
+    "Unthemed",
+    "testdata",
+    "testid"
+  ],
+  "ignoreRegExpList": ["@[\\w]+"]
 }

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -1,16 +1,24 @@
 {
-  "ignorePaths": ["node_modules/**", "dist/**", "src/external/**", "src/**/*.tsx", "provisioning/**", "package.json"],
-  "words": [
-    "gdev",
-    "grafana",
-    "datasource",
-    "datasources",
-    "rgba",
-    "countup",
-    "Themeable",
-    "Unthemed",
-    "testdata",
-    "testid"
-  ],
-  "ignoreRegExpList": ["@[\\w]+"]
+    "ignorePaths": [
+        "node_modules/**",
+        "dist/**",
+        "src/external/**",
+        "provisioning/**",
+        "package.json"
+    ],
+    "words": [
+        "gdev",
+        "grafana",
+        "datasource",
+        "datasources",
+        "rgba",
+        "countup",
+        "Themeable",
+        "Unthemed",
+        "testdata",
+        "testid"
+    ],
+    "ignoreRegExpList": [
+        "@[\\w]+"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clock-panel",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Clock Panel Plugin for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -103,6 +103,10 @@ const migrateInputOnlyPluginConfig = (panel: PanelModel<ClockOptions>) => {
         queryType: 'randomWalk',
       },
     ];
+    panel.datasource = {
+      type: grafanaDs.type,
+      uid: grafanaDs.uid,
+    };
   } else {
     // remove the targets
     panel.targets = [];

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -78,11 +78,13 @@ const detectInputOnlyPluginConfig = (panel: PanelModel<ClockOptions>) => {
 const migrateInputOnlyPluginConfig = (panel: PanelModel<ClockOptions>) => {
   // remove the datasource
   delete panel.datasource;
+  // remove the targets
+  panel.targets = [];
 
+  // find the grafana datasource and set it if available
   const datasources = config.datasources || [];
   let grafanaDs: (typeof datasources)[number] | undefined = undefined;
 
-  // find the grafana datasource
   for (let datasourceKey of Object.keys(datasources)) {
     const ds = datasources[datasourceKey];
     if (ds.uid === 'grafana' || (ds.name === '-- Grafana --' && ds.type === 'datasource')) {
@@ -107,9 +109,6 @@ const migrateInputOnlyPluginConfig = (panel: PanelModel<ClockOptions>) => {
       type: grafanaDs.type,
       uid: grafanaDs.uid,
     };
-  } else {
-    // remove the targets
-    panel.targets = [];
   }
 };
 

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -83,8 +83,8 @@ const migrateInputOnlyPluginConfig = (panel: PanelModel<ClockOptions>) => {
   let grafanaDs: (typeof datasources)[number] | undefined = undefined;
 
   // find the grafana datasource
-  for (let dskey of Object.keys(datasources)) {
-    const ds = datasources[dskey];
+  for (let datasourceKey of Object.keys(datasources)) {
+    const ds = datasources[datasourceKey];
     if (ds.uid === 'grafana' || (ds.name === '-- Grafana --' && ds.type === 'datasource')) {
       grafanaDs = ds;
       break;


### PR DESCRIPTION
This PR improves the migration logic in the clock panel to prevent clocks that use direct inputs instead of queries displaying possible datasource errors.

This might fix https://github.com/grafana/clock-panel/issues/200 but won't work 100% of all cases
