### PR TITLE
CD job requires content write

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
     name: CD
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main # zizmor: ignore[unpinned-uses]
     permissions:
-      contents: read
+      contents: write
       id-token: write
       attestations: write
     with:


### PR DESCRIPTION
Adding `contents:write` permission or otherwise it fails with

https://github.com/grafana/clock-panel/actions/runs/15164732586

> The workflow is not valid. .github/workflows/publish.yml (Line: 26, Col: 3): Error calling workflow 'grafana/plugin-ci-workflows/.github/workflows/cd.yml@main'. The workflow is requesting 'contents: write', but is only allowed 'contents: read'.Show less