### PR TITLE
chore: change push.yml back to use ci

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v1.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v1.2.0
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Change `push.yml` back to use `grafana/plugin-ci-workflows/.github/workflows/ci.yml` instead of `grafana/plugin-ci-workflows/.github/workflows/cd.yml`