### PR TITLE
Chore: move groupings over to renovate and disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,62 +1,62 @@
-# Basic set up for three package managers
-version: 2
-updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    schedule:
-      interval: 'monthly'
+# # Basic set up for three package managers
+# version: 2
+# updates:
+#   # Maintain dependencies for GitHub Actions
+#   - package-ecosystem: 'github-actions'
+#     directory: '/'
+#     schedule:
+#       interval: 'monthly'
 
-  # Maintain dependencies for npm
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'monthly'
-    open-pull-requests-limit: 5
-    groups:
-      # Grafana framework dependencies
-      grafana:
-        patterns:
-          - "@grafana/*"
+#   # Maintain dependencies for npm
+#   - package-ecosystem: 'npm'
+#     directory: '/'
+#     schedule:
+#       interval: 'monthly'
+#     open-pull-requests-limit: 5
+#     groups:
+#       # Grafana framework dependencies
+#       grafana:
+#         patterns:
+#           - "@grafana/*"
         
-      # Runtime dependencies (React and date/time libraries)
-      runtime:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-          - "moment*"
+#       # Runtime dependencies (React and date/time libraries)
+#       runtime:
+#         patterns:
+#           - "react"
+#           - "react-dom"
+#           - "@types/react"
+#           - "@types/react-dom"
+#           - "moment*"
         
-      # Development tools (testing, linting, and build tools)
-      dev-tools:
-        patterns:
-          - "jest*"
-          - "@jest/*"
-          - "@testing-library/*"
-          - "@swc/jest"
-          - "@playwright/test"
-          - "@types/jest"
-          - "@types/testing-library*"
-          - "eslint*"
-          - "@typescript-eslint/*"
-          - "@stylistic/*"
-          - "prettier"
-          - "cspell"
-          - "webpack*"
-          - "*-webpack-plugin"
-          - "*-loader"
-          - "@swc/core"
-          - "swc-loader"
-          - "terser-webpack-plugin"
+#       # Development tools (testing, linting, and build tools)
+#       dev-tools:
+#         patterns:
+#           - "jest*"
+#           - "@jest/*"
+#           - "@testing-library/*"
+#           - "@swc/jest"
+#           - "@playwright/test"
+#           - "@types/jest"
+#           - "@types/testing-library*"
+#           - "eslint*"
+#           - "@typescript-eslint/*"
+#           - "@stylistic/*"
+#           - "prettier"
+#           - "cspell"
+#           - "webpack*"
+#           - "*-webpack-plugin"
+#           - "*-loader"
+#           - "@swc/core"
+#           - "swc-loader"
+#           - "terser-webpack-plugin"
         
-      # TypeScript related
-      typescript:
-        patterns:
-          - "typescript"
-          - "ts-node"
-          - "@types/*"
-                 exclude-patterns:
-           - "@types/react*"
-           - "@types/jest"
-           - "@types/testing-library*"
+#       # TypeScript related
+#       typescript:
+#         patterns:
+#           - "typescript"
+#           - "ts-node"
+#           - "@types/*"
+#                  exclude-patterns:
+#            - "@types/react*"
+#            - "@types/jest"
+#            - "@types/testing-library*"

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -1,5 +1,5 @@
 {
-  "ignorePaths": ["node_modules/**", "dist/**", "src/external/**", "provisioning/**", "package.json"],
+  "ignorePaths": ["node_modules/**", "dist/**", "src/external/**", "provisioning/**", "package.json", "renovate.json"],
   "words": [
     "gdev",
     "grafana",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,61 @@
+{
+    "ignorePresets": [
+        "github>grafana/grafana-renovate-config//presets/automerge",
+        "github>grafana/grafana-renovate-config//presets/labels"        
+    ],
+    "packageRules": [
+        {
+            "groupName": "grafana",
+            "matchPackageNames": [
+                "/^@grafana/"
+            ],
+            "minimumReleaseAge": null
+        },
+        {
+            "groupName": "runtime",
+            "matchPackageNames": [
+                "/^react$/",
+                "/^react-dom$/",
+                "/^@types/react$/",
+                "/^@types/react-dom$/",
+                "/^moment($|-)/"
+            ]
+        },
+        {
+            "groupName": "dev-tools",
+            "matchPackageNames": [
+                "/^jest/",
+                "/^@jest\//",
+                "/^@testing-library\//",
+                "/^@swc/jest$/",
+                "/^@playwright/test$/",
+                "/^@types/jest$/",
+                "/^@types/testing-library/",
+                "/^eslint/",
+                "/^@typescript-eslint\//",
+                "/^@stylistic\//",
+                "/^prettier$/",
+                "/^cspell$/",
+                "/^webpack/",
+                "/.*-webpack-plugin$/",
+                "/.*-loader$/",
+                "/^@swc/core$/",
+                "/^swc-loader$/",
+                "/^terser-webpack-plugin$/"
+            ]
+        },
+        {
+            "groupName": "typescript",
+            "matchPackageNames": [
+                "/^typescript$/",
+                "/^ts-node$/",
+                "/^@types\//",
+                "!/^@types/react/",
+                "!/^@types/jest/",
+                "!/^@types/testing-library/"
+            ]
+        }
+    ],
+    "minimumReleaseAge": "14 days",
+    "prConcurrentLimit": 10    
+}


### PR DESCRIPTION
Moving to our self hosted renovate config while keeping the package groups together.

Config seems to be alright
```
npx --yes --package renovate -- renovate-config-validator 
 INFO: Validating renovate.json
 INFO: Config validated successfully
```