### PR TITLE
Add extends for plugin-ci-workflows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,10 @@
 {
     "ignorePresets": [
         "github>grafana/grafana-renovate-config//presets/automerge",
-        "github>grafana/grafana-renovate-config//presets/labels"        
+        "github>grafana/grafana-renovate-config//presets/labels"
+    ],
+    "extends": [
+        "github>grafana/grafana-renovate-config//presets/plugin-ci-workflows"
     ],
     "packageRules": [
         {


### PR DESCRIPTION
[plugin-ci-workflows](https://github.com/grafana/grafana-renovate-config/blob/main/presets/plugin-ci-workflows.json) preset is opt-in, adding this opt-in to the renovate config.