### PR TITLE
Removing renovate dependency dashboard and just using best practices by default

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,11 @@
 {
     "ignorePresets": [
+        "github>grafana/grafana-renovate-config//presets/base",
         "github>grafana/grafana-renovate-config//presets/automerge",
         "github>grafana/grafana-renovate-config//presets/labels"
     ],
     "extends": [
+        "config:best-practices",
         "github>grafana/grafana-renovate-config//presets/plugin-ci-workflows"
     ],
     "packageRules": [


### PR DESCRIPTION
On the journey for the optimal renovate config