### PR TITLE
Bring back minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -61,5 +61,6 @@
             ]
         }
     ],    
-    "prConcurrentLimit": 10    
+    "prConcurrentLimit": 10,
+    "minimumReleaseAge": "14 days"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
     "ignorePresets": [
         "github>grafana/grafana-renovate-config//presets/base",
         "github>grafana/grafana-renovate-config//presets/automerge",
-        "github>grafana/grafana-renovate-config//presets/labels"
+        "github>grafana/grafana-renovate-config//presets/labels",
+        "github>grafana/grafana-renovate-config//presets/npm"
     ],
     "extends": [
         "config:best-practices",


### PR DESCRIPTION
We have [removed it previously](https://github.com/grafana/clock-panel/pull/349) to test workflow updates, now bringing it back to "normal", also adding npm preset to ignore list