### PR TITLE
chore: make sure the renovate PRs are up to date

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,5 +63,6 @@
         }
     ],    
     "prConcurrentLimit": 10,
-    "minimumReleaseAge": "14 days"
+    "minimumReleaseAge": "14 days",
+    "rebaseWhen": "behind-base-branch"
 }


### PR DESCRIPTION
Trying to use rebaseWhen config to automatically rebase PRs when they are behind main branch, should save some time checking the checkbox manually.