### PR TITLE
chore: disable dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     ],
     "extends": [
         "config:best-practices",
+        ":disableDependencyDashboard",
         "github>grafana/grafana-renovate-config//presets/plugin-ci-workflows"
     ],
     "packageRules": [


### PR DESCRIPTION
Getting rid of renovate's dependency dashboard issue creation