### PR TITLE
Chore: fix permissions for Crowdin workflows

### DIFF
--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -1,9 +1,5 @@
 name: Crowdin Download Action
 
-permissions:
-  contents: read
-  pull-requests: write
-
 on:
   workflow_dispatch:
   schedule:
@@ -11,8 +7,13 @@ on:
 
 jobs:
   download-sources-from-crowdin:
-    uses: grafana/grafana-github-actions/.github/workflows/crowdin-download.yml@main
+    uses: grafana/grafana-github-actions/.github/workflows/crowdin-download.yml@7d2b4af1112747f82e12adfbc00be44fecb3b616
     with:
       crowdin_project_id: 36
       pr_labels: 'i18n'
       github_board_id: 76 # Plugins Platform / Grafana Community project
+
+    permissions:
+      contents: write # needed to commit changes into the PR
+      pull-requests: write # needed to update PR description, labels, etc
+      id-token: write # needed to get vault secrets

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -1,8 +1,5 @@
 name: Crowdin Upload Action
 
-permissions:
-  contents: read
-
 on:
   workflow_dispatch:
   push:
@@ -13,6 +10,10 @@ on:
 
 jobs:
   upload-sources-to-crowdin:
-    uses: grafana/grafana-github-actions/.github/workflows/crowdin-upload.yml@main
+    uses: grafana/grafana-github-actions/.github/workflows/crowdin-upload.yml@43c2b343f8b0e4acb0f0557c62e326780acc19d2
     with:
       crowdin_project_id: 36
+
+    permissions:
+      contents: read
+      id-token: write # needed to get vault secrets

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,12 @@
+# The following are pulled from env variables
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+preserve_hierarchy: true
+files:
+  [
+    {
+      'source': 'src/locales/en-US/grafana-clock-panel.json',
+      'translation': 'src/locales/%locale%/%original_file_name%',
+      'type': 'i18next_json',
+    },
+  ]


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for Crowdin integration and adds a new configuration file for Crowdin. The main changes focus on improving permissions management, specifying workflow versions, and introducing a Crowdin configuration file.

Working runs:
- https://github.com/grafana/clock-panel/actions/runs/18397361687/job/52419251396
- https://github.com/grafana/clock-panel/actions/runs/18397381063/job/52419298623