### PR TITLE
Add ignore presets to the main file

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>grafana/grafana-community-team//renovate/renovate"],
+  "ignorePresets": [
+    "github>grafana/grafana-renovate-config//presets/base",
+    "github>grafana/grafana-renovate-config//presets/automerge",
+    "github>grafana/grafana-renovate-config//presets/labels",
+    "github>grafana/grafana-renovate-config//presets/npm"
+  ],
+  "labels": ["dependencies", "javascript"],
   "packageRules": [
     {
       "groupName": "grafana",


### PR DESCRIPTION
Looks like it does not inherit the ignores from 
`github>grafana/grafana-community-team//renovate/renovate` due to https://docs.renovatebot.com/config-overview/#you-can-not-ignore-presets-from-inherited-config