### PR TITLE
Release: the Clock panel is now available in 19 languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Change Log
 
+## 3.1.0
+
+- The Clock panel is now available in the following languages:
+  - English (en-US)
+  - Čeština (cs-CZ)
+  - Deutsch (de-DE)
+  - Español (es-ES)
+  - Français (fr-FR)
+  - Magyar (hu-HU)
+  - Bahasa Indonesia (id-ID)
+  - Italiano (it-IT)
+  - 日本語 (ja-JP)
+  - 한국어 (ko-KR)
+  - Nederlands (nl-NL)
+  - Polski (pl-PL)
+  - Português Brasileiro (pt-BR)
+  - Português (pt-PT)
+  - Русский (ru-RU)
+  - Svenska (sv-SE)
+  - Türkçe (tr-TR)
+  - 中文（简体）(zh-Hans)
+  - 中文（繁體）(zh-Hant)
+
 ## 3.0.1
 
 - Fixes [#408](https://github.com/grafana/clock-panel/issues/408)

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -18,7 +18,19 @@
     "Themeable",
     "Unthemed",
     "testdata",
-    "testid"
+    "testid",
+    "Čeština",
+    "Deutsch",
+    "Bahasa",
+    "Italiano",
+    "Nederlands",
+    "Polski",
+    "Português",
+    "Brasileiro",
+    "Português",
+    "Русский",
+    "Svenska",
+    "Türkçe"
   ],
   "ignoreRegExpList": ["@[\\w]+"]
 }

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -22,6 +22,8 @@
     "Čeština",
     "Deutsch",
     "Bahasa",
+    "Español",
+    "Français",
     "Italiano",
     "Nederlands",
     "Polski",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clock-panel",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Clock Panel Plugin for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
This pull request updates the Clock Panel plugin to version 3.1.0 and introduces expanded language support for the Clock panel. The most significant change is the addition of support for 19 languages, making the panel more accessible to international users.

Internationalization:

* The Clock panel is now available in 19 languages, including English, Czech, German, Spanish, French, Hungarian, Indonesian, Italian, Japanese, Korean, Dutch, Polish, Brazilian Portuguese, European Portuguese, Russian, Swedish, Turkish, Simplified Chinese, and Traditional Chinese (`CHANGELOG.md`).

Release management:

* Bumped the plugin version from 3.0.1 to 3.1.0 in `package.json` to reflect the new release.