### PR TITLE
Fix: fixes `Each child in a list should have a unique "key" prop` warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 3.2.1
+
+- Fixes React unique child key error
+
 ## 3.2.0
 
 - Add `Digital` clock style 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clock-panel",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clock-panel",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clock-panel",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Clock Panel Plugin for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/components/digital/Digit.tsx
+++ b/src/components/digital/Digit.tsx
@@ -34,7 +34,7 @@ const digits: Record<number, string[]> = {
 };
 
 interface DigitProps {
-  parentKey: string;
+  fragmentKey: string;
   char: string;
   stroke: string;
   strokeWidth: number;
@@ -43,7 +43,7 @@ interface DigitProps {
   x?: number;
 }
 
-export function Digit({ parentKey, char, fill, filter, stroke, strokeWidth, x = 0 }: DigitProps) {
+export function Digit({ fragmentKey, char, fill, filter, stroke, strokeWidth, x = 0 }: DigitProps) {
   const digit = parseInt(char, 10);
 
   if (!digits[digit]) {
@@ -56,7 +56,7 @@ export function Digit({ parentKey, char, fill, filter, stroke, strokeWidth, x = 
     <>
       {digits[digit].map((d, index) => (
         <path
-          key={`${parentKey}-${index}-digit`}
+          key={`${fragmentKey}-${index}-digit`}
           d={d}
           stroke={stroke}
           strokeWidth={strokeWidth}

--- a/src/components/digital/DigitalTime.tsx
+++ b/src/components/digital/DigitalTime.tsx
@@ -12,7 +12,7 @@ import {
   SVG_VIEW_BOX_WIDTH,
 } from '../../constants';
 import { Dash } from './Dash';
-import { getWidth } from './utils';
+import { getFragmentKey, getWidth } from './utils';
 
 interface RenderDigitalTimeProps {
   text: string;
@@ -71,17 +71,17 @@ export function DigitalTime({ text, width: panelWidth, height: panelHeight, opti
         x += getWidth(char, chars[charIndex - 1]);
         const digit = parseInt(char, 10);
         const isDigit = !isNaN(digit);
+        const fragmentKey = getFragmentKey(key, char, charIndex);
 
         return (
-          <>
+          <React.Fragment key={fragmentKey}>
             {isDigit && (
               <Digit
                 x={x}
                 char={char}
                 fill={fill}
                 filter={`url(#${filterId})`}
-                key={`${key}-${charIndex}-digit`}
-                parentKey={`${key}-${charIndex}-digit`}
+                fragmentKey={fragmentKey}
                 stroke={stroke}
                 strokeWidth={strokeWidth}
               />
@@ -92,7 +92,6 @@ export function DigitalTime({ text, width: panelWidth, height: panelHeight, opti
                 char={char}
                 fill={fill}
                 filter={`url(#${filterId})`}
-                key={`${key}-${charIndex}-colon`}
                 stroke={stroke}
                 strokeWidth={strokeWidth}
               />
@@ -103,7 +102,6 @@ export function DigitalTime({ text, width: panelWidth, height: panelHeight, opti
                 char={char}
                 fill={fill}
                 filter={`url(#${filterId})`}
-                key={`${key}-${charIndex}-dash`}
                 stroke={stroke}
                 strokeWidth={strokeWidth}
               />
@@ -114,12 +112,11 @@ export function DigitalTime({ text, width: panelWidth, height: panelHeight, opti
                 char={char}
                 fill={fill}
                 filter={`url(#${filterId})`}
-                key={`${key}-${charIndex}-colon`}
                 stroke={stroke}
                 strokeWidth={strokeWidth}
               />
             )}
-          </>
+          </React.Fragment>
         );
       })}
     </svg>

--- a/src/components/digital/utils.test.ts
+++ b/src/components/digital/utils.test.ts
@@ -1,5 +1,5 @@
 import { ClockOptions, DescriptionSource } from 'types';
-import { getHeights, getWidth } from './utils';
+import { getFragmentKey, getHeights, getWidth } from './utils';
 
 describe('getWidth', () => {
   it.each([
@@ -137,4 +137,19 @@ describe('getHeights', () => {
       expect(getHeights(panelHeight, options).zone).toBe(12.166666666666666);
     });
   });
+});
+
+describe('getFragmentKey', () => {
+  it.each([
+    { key: 'some-key', char: '1', charIndex: 0, expected: 'some-key-0-digit' },
+    { key: 'some-key', char: '1', charIndex: 2, expected: 'some-key-2-digit' },
+    { key: 'key', char: ':', charIndex: 0, expected: 'key-0-colon' },
+    { key: 'k', char: '-', charIndex: 1, expected: 'k-1-dash' },
+    { key: 't', char: 't', charIndex: 5, expected: 't-5-text' },
+  ])(
+    `when called with $key, $char and $charIndex then the result should be $expected`,
+    ({ key, char, charIndex, expected }) => {
+      expect(getFragmentKey(key, char, charIndex)).toBe(expected);
+    }
+  );
 });

--- a/src/components/digital/utils.ts
+++ b/src/components/digital/utils.ts
@@ -44,3 +44,22 @@ export function getHeights(panelHeight: number, options: ClockOptions): Heights 
     zone,
   };
 }
+
+export function getFragmentKey(key: string, char: string, charIndex: number) {
+  const digit = parseInt(char, 10);
+  const isDigit = !isNaN(digit);
+
+  if (isDigit) {
+    return `${key}-${charIndex}-digit`;
+  }
+
+  if (char === ':') {
+    return `${key}-${charIndex}-colon`;
+  }
+
+  if (char === '-') {
+    return `${key}-${charIndex}-dash`;
+  }
+
+  return `${key}-${charIndex}-text`;
+}


### PR DESCRIPTION
While working on something else I noticed that the new `Digital` clock style was throwing `Each child in a list should have a unique "key" prop.` warning.

```log
installHook.js:1 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `DigitalTime`. See https://reactjs.org/link/warning-keys for more information. Error Component Stack
    at DigitalTime (DigitalTime.tsx:24:31)
    at RenderTime (RenderTime.tsx:164:30)
    at div (<anonymous>)
    at ClockPanel (ClockPanel.tsx:19:11)
    at PluginContextProvider (PluginContextProvider.tsx:12:11)
    at ErrorBoundary (ErrorBoundary.tsx:42:8)
    at ErrorBoundary.tsx:121:6
    at div (<anonymous>)
    at section (<anonymous>)
    at div (<anonymous>)
    at MaybeWrap (PanelChrome.tsx:118:22)
    at PanelChrome (PanelChrome.tsx:136:3)
    at div (<anonymous>)
    at div (<anonymous>)
    at VizPanelRenderer (index.js:7549:29)
    at SceneComponentWrapperWithoutMemo (index.js:116:45)
    at div (<anonymous>)
    at index.js:7491:6
    at PanelWrapper (DashboardGridItemRenderer.tsx:21:25)
    at DashboardGridItemRenderer (DashboardGridItemRenderer.tsx:36:45)
    at SceneComponentWrapperWithoutMemo (index.js:116:45)
    at div (<anonymous>)
    at index.js:7491:6
    at index.js:13670:11
    at Resizable (Resizable.js:30:1)
    at DraggableCore (DraggableCore.js:75:1)
    at GridItem (GridItem.js:112:1)
    at div (<anonymous>)
    at ReactGridLayout (ReactGridLayout.js:67:1)
    at div (<anonymous>)
    at div (<anonymous>)
    at SceneGridLayoutRenderer (index.js:13606:36)
    at SceneComponentWrapperWithoutMemo (index.js:116:45)
    at div (<anonymous>)
    at DefaultGridLayoutManagerRenderer (DefaultGridLayoutManager.tsx:634:45)
    at SceneComponentWrapperWithoutMemo (index.js:116:45)
    at div (<anonymous>)
    at div (<anonymous>)
    at NativeScrollbar (NativeScrollbar.tsx:14:43)
    at DashboardEditPaneSplitter (DashboardEditPaneSplitter.tsx:30:45)
    at div (<anonymous>)
    at Page (Page.tsx:18:3)
    at DashboardSceneRenderer (DashboardSceneRenderer.tsx:17:42)
    at SceneComponentWrapperWithoutMemo (index.js:116:45)
    at UrlSyncContextProvider (index.js:13372:1)
    at DashboardScenePage (DashboardScenePage.tsx:27:38)
    at DashboardPageProxy (DashboardPageProxy.tsx:24:29)
    at Suspense (<anonymous>)
    at ErrorBoundary (ErrorBoundary.tsx:42:8)
    at GrafanaRoute (GrafanaRoute.tsx:18:45)
    at GrafanaRouteWrapper (GrafanaRoute.tsx:64:39)
    at RenderedRoute (index.js:517:1)
    at Routes (index.js:1218:1)
    at div (<anonymous>)
    at Stack.tsx:29:5
    at main (<anonymous>)
    at div (<anonymous>)
    at div (<anonymous>)
    at div (<anonymous>)
    at AppChrome (AppChrome.tsx:32:29)
    at ModalsContextProvider (ModalsContextProvider.tsx:27:37)
    at ExtraProviders (RoutesWrapper.tsx:15:16)
    at QueriesDrawerContextProvider (QueriesDrawerContext.tsx:31:48)
    at RenderedRoute (index.js:517:1)
    at Routes (index.js:1218:1)
    at Router (index.js:1152:1)
    at CompatRouter (index.js:1470:1)
    at LocationServiceProvider (LocationService.tsx:192:3)
    at Router (react-router.js:233:1)
    at RouterWrapper (RoutesWrapper.tsx:32:46)
    at div (<anonymous>)
    at $96b38030c423d352$export$78efe591171d7d45 (PortalProvider.mjs:16:11)
    at ExtensionSidebarContextProvider (ExtensionSidebarProvider.tsx:69:51)
    at ExtensionRegistriesProvider (ExtensionRegistriesContext.tsx:53:3)
    at ScopesContextProvider (ScopesContextProvider.tsx:46:41)
    at KBarProvider (KBarContextProvider.js:28:1)
    at CacheProvider (provider.mjs:9:26)
    at SkeletonTheme (index.js:97:26)
    at ThemeProvider (ConfigProvider.tsx:12:33)
    at ErrorBoundary (ErrorBoundary.tsx:42:8)
    at ErrorBoundary.tsx:121:6
    at Provider (react-redux.mjs:875:11)
    at AppWrapper (AppWrapper.tsx:54:5)
```