### PR TITLE
Update Renovate configuration to ignore specific paths

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>grafana/grafana-community-team//renovate/renovate"],
+  "ignorePresets": [
+    "github>grafana/grafana-renovate-config//presets/base",
+    "github>grafana/grafana-renovate-config//presets/automerge",
+    "github>grafana/grafana-renovate-config//presets/labels",
+    "github>grafana/grafana-renovate-config//presets/npm"
+  ],
   "ignorePaths": [
     "**/fixtures/**/package.json",
     "**/tests/**/package.json",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,56 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>grafana/grafana-community-team//renovate/renovate"],
-  "ignorePresets": [
-    "github>grafana/grafana-renovate-config//presets/base",
-    "github>grafana/grafana-renovate-config//presets/automerge",
-    "github>grafana/grafana-renovate-config//presets/labels",
-    "github>grafana/grafana-renovate-config//presets/npm"
+  "ignorePaths": [
+    "**/fixtures/**/package.json",
+    "**/tests/**/package.json",
+    "**/test/**/package.json"
   ],
-  "labels": ["dependencies", "javascript"],
   "packageRules": [
     {
-      "groupName": "grafana",
-      "matchPackageNames": ["/^@grafana/"],
-      "minimumReleaseAge": null
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "description": "Group GitHub Actions updates"
     },
     {
-      "groupName": "runtime",
-      "matchPackageNames": ["/^moment($|-)/"]
-    },
-    {
-      "groupName": "dev-tools",
-      "matchPackageNames": [
-        "/^jest/",
-        "/^@jest\//",
-        "/^@testing-library\//",
-        "/^@swc/jest$/",
-        "/^@playwright/test$/",
-        "/^@types/jest$/",
-        "/^@types/testing-library/",
-        "/^eslint/",
-        "/^@typescript-eslint\//",
-        "/^@stylistic\//",
-        "/^prettier$/",
-        "/^cspell$/",
-        "/^webpack/",
-        "/.*-webpack-plugin$/",
-        "/.*-loader$/",
-        "/^@swc/core$/",
-        "/^swc-loader$/",
-        "/^terser-webpack-plugin$/"
-      ]
-    },
-    {
-      "groupName": "typescript",
-      "matchPackageNames": [
-        "/^typescript$/",
-        "/^ts-node$/",
-        "/^@types\//",
-        "!/^@types/react/",
-        "!/^@types/jest/",
-        "!/^@types/testing-library/"
-      ]
+      "matchManagers": ["npm"],
+      "groupName": "npm dependencies",
+      "description": "Group all other npm dependencies"
     }
-  ]
+  ],
+  "labels": ["dependencies"]
 }


### PR DESCRIPTION
The current config it's making renovate create a PR for each dependency. this makes it open a single one. 