### PR TITLE
Workflows: Use main branch for testing Grafana react preview image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ permissions: {}
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v3.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v3.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
This PR temporarily updates the workflow references to use the main branch to test the [Grafana react preview image](https://github.com/grafana/plugin-actions/pull/192). This change will be reverted once this feature is shipped in an actual release of the shared workflows.