### PR TITLE
chore: make plugin react 19 ready

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ permissions: {}
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v3.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v6.0.0
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v3.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v6.0.0
     permissions:
       contents: read
       id-token: write

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@emotion/css": "^11.13.5",
         "@grafana/data": "^12.2.0",
-        "@grafana/i18n": "^12.2.0",
+        "@grafana/i18n": "12.4.0-21947912385",
         "@grafana/runtime": "^12.2.0",
         "@grafana/schema": "^12.2.0",
         "@grafana/ui": "^12.2.0",
@@ -1949,6 +1949,25 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@grafana/data/node_modules/@grafana/i18n": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.2.0.tgz",
+      "integrity": "sha512-eFrPfJMwj8/XFuMMmI5HkT1qtpRIvYvMy2EgCbFRZzPhBrFdVcO4eWpScNm57F599/L+p0+odMW5L/FJ4ukXlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@formatjs/intl-durationformat": "^0.7.0",
+        "@typescript-eslint/utils": "^8.33.1",
+        "fast-deep-equal": "^3.1.3",
+        "i18next": "^25.0.0",
+        "i18next-browser-languagedetector": "^8.0.0",
+        "i18next-pseudo": "^2.2.1",
+        "micro-memoize": "^4.1.2",
+        "react-i18next": "^15.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
     "node_modules/@grafana/data/node_modules/moment-timezone": {
       "version": "0.5.47",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.47.tgz",
@@ -2042,9 +2061,9 @@
       }
     },
     "node_modules/@grafana/i18n": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.2.0.tgz",
-      "integrity": "sha512-eFrPfJMwj8/XFuMMmI5HkT1qtpRIvYvMy2EgCbFRZzPhBrFdVcO4eWpScNm57F599/L+p0+odMW5L/FJ4ukXlA==",
+      "version": "12.4.0-21947912385",
+      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.4.0-21947912385.tgz",
+      "integrity": "sha512-fzx0SPXtgI5ZBFl0cDJIkhFdAs2LUl+s1rRAbD64YldhRapEHw/aOhbBvrqi5KM/ZqmcbW/MHymFfmi98MfrBw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@formatjs/intl-durationformat": "^0.7.0",
@@ -2264,6 +2283,25 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@grafana/i18n": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.2.0.tgz",
+      "integrity": "sha512-eFrPfJMwj8/XFuMMmI5HkT1qtpRIvYvMy2EgCbFRZzPhBrFdVcO4eWpScNm57F599/L+p0+odMW5L/FJ4ukXlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@formatjs/intl-durationformat": "^0.7.0",
+        "@typescript-eslint/utils": "^8.33.1",
+        "fast-deep-equal": "^3.1.3",
+        "i18next": "^25.0.0",
+        "i18next-browser-languagedetector": "^8.0.0",
+        "i18next-pseudo": "^2.2.1",
+        "micro-memoize": "^4.1.2",
+        "react-i18next": "^15.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
       }
     },
     "node_modules/@grafana/ui/node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.5",
     "@grafana/data": "^12.2.0",
-    "@grafana/i18n": "^12.2.0",
+    "@grafana/i18n": "12.4.0-21947912385",
     "@grafana/runtime": "^12.2.0",
     "@grafana/schema": "^12.2.0",
     "@grafana/ui": "^12.2.0",

--- a/src/ClockPanel.tsx
+++ b/src/ClockPanel.tsx
@@ -12,6 +12,7 @@ import { CalculateClockOptions } from 'components/CalculateClockOptions';
 import { RenderDescription } from 'components/RenderDescription';
 import { useInteraction } from 'hooks/useInteraction';
 import { useClockStyles } from 'hooks/useClockStyles';
+import { TEST_IDS } from './constants';
 
 interface Props extends PanelProps<ClockOptions> {}
 
@@ -55,6 +56,7 @@ export function ClockPanel(props: Props) {
   return (
     <div
       className={panel}
+      data-testid={TEST_IDS.clockPanel}
       style={{
         width,
         height,

--- a/src/components/RenderTime.tsx
+++ b/src/components/RenderTime.tsx
@@ -5,6 +5,7 @@ import { ClockMode, ClockOptions, ClockStyle, ClockType, TimeSettings } from 'ty
 import { DigitalTime } from './digital/DigitalTime';
 import { getHeights } from './digital/utils';
 import { useClockStyles } from 'hooks/useClockStyles';
+import { TEST_IDS } from '../constants';
 
 function getStrings() {
   const oneYear = t('components.RenderTime.getStrings.oneYear', '1 year');
@@ -194,5 +195,9 @@ export function RenderTime({ now, options, targetTime, err, width, height }: Ren
     return <DigitalTime text={display} width={width} height={getHeights(height, options).time} options={options} />;
   }
 
-  return <h2 className={time}>{display}</h2>;
+  return (
+    <h2 className={time} data-testid={TEST_IDS.clockPanelTime}>
+      {display}
+    </h2>
+  );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,3 +6,8 @@ export const SVG_VIEW_BOX_HEIGHT = 234;
 export const SVG_SEPARATORS = [':', '-'];
 export const SVG_DIGITS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
 export const SVG_DIGITIZED = SVG_DIGITS.concat(SVG_SEPARATORS);
+
+export const TEST_IDS = {
+  clockPanel: 'clock-panel',
+  clockPanelTime: 'clock-panel-time',
+};

--- a/tests/default-panel/create-panel.spec.ts
+++ b/tests/default-panel/create-panel.spec.ts
@@ -1,7 +1,11 @@
 import { expect, test } from '@grafana/plugin-e2e';
+import { TEST_IDS } from '../../src/constants';
 
-test('should return clock panel', async ({ panelEditPage }) => {
+test('should return clock panel', async ({ panelEditPage, page }) => {
   await panelEditPage.datasource.set('ClockTestData');
   await panelEditPage.setVisualization('Clock');
   await expect(panelEditPage.refreshPanel()).toBeOK();
+  const clockPanel = page.getByTestId(TEST_IDS.clockPanel);
+  await expect(clockPanel).toBeVisible();
+  await expect(clockPanel.getByTestId(TEST_IDS.clockPanelTime)).toBeVisible();
 });


### PR DESCRIPTION
Bumps the grafana/i18n package to stop webpack bundling react/jsx-runtime. I did consider externalising jsx-runtime instead but this plugin has hardly any dependencies and is the most downloaded plugin in the grafana catalog so went the route of bumping the package to continue providing the translations in a backwards compatible way.

I've also added the react-19 image to the ci workflows and added checks to the smoke test that asserts the panel renders a clock.

Fixes: #499 

