### PR TITLE
chore: bump plugin version to 3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clock-panel",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clock-panel",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clock-panel",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Clock Panel Plugin for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Now #500 is merged we can cut a new patch release so the plugin is React 18 and 19 compatible.