### PR TITLE
chore: bump plugin-e2e to latest to fix e2e tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@grafana/eslint-config": "^9.0.0",
         "@grafana/eslint-plugin-plugins": "0.6.0",
-        "@grafana/plugin-e2e": "^3.1.3",
+        "@grafana/plugin-e2e": "^3.3.0",
         "@grafana/tsconfig": "^2.0.0",
         "@playwright/test": "1.57.0",
         "@stylistic/eslint-plugin-ts": "4.4.1",
@@ -2120,13 +2120,13 @@
       }
     },
     "node_modules/@grafana/plugin-e2e": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.1.3.tgz",
-      "integrity": "sha512-DHCAaoH+9smFmD410r8aECLqO5VkGrenTRQojmUTcrRreFrwBjTd1gt8U9UILXKR0gOCe9XBrB3HKil1yc1CoQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.3.0.tgz",
+      "integrity": "sha512-sWxwG+cSVOoWhARMme0H4WRK3uUl2fraQ1p0WHkZXCPt7mkMbj6XrZkwRHogFCsMCPle5YViNbIBVHqKSMBsjQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/e2e-selectors": "12.4.0-20331417332",
+        "@grafana/e2e-selectors": "12.4.0-21636304584",
         "semver": "^7.5.4",
         "uuid": "^13.0.0",
         "yaml": "^2.3.4"
@@ -2139,9 +2139,9 @@
       }
     },
     "node_modules/@grafana/plugin-e2e/node_modules/@grafana/e2e-selectors": {
-      "version": "12.4.0-20331417332",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.4.0-20331417332.tgz",
-      "integrity": "sha512-siY5jyqq3iKuataiyanlcxlmblIE/jU75U46AxepaJfgGtyTKAzWGCy9EH631BNyrMchImSnk38p2wuN7X/zqQ==",
+      "version": "12.4.0-21636304584",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.4.0-21636304584.tgz",
+      "integrity": "sha512-cvpFXsYIImpqmYYLqPuJ0SRWDsgj556ByeMs25wgyC4/96QQX2IxzZjWc4qIdfZYSGRzuCHYsgDvWjqJ5fPd4g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@grafana/eslint-config": "^9.0.0",
     "@grafana/eslint-plugin-plugins": "0.6.0",
-    "@grafana/plugin-e2e": "^3.1.3",
+    "@grafana/plugin-e2e": "^3.3.0",
     "@grafana/tsconfig": "^2.0.0",
     "@playwright/test": "1.57.0",
     "@stylistic/eslint-plugin-ts": "4.4.1",


### PR DESCRIPTION
Fixes failing canary e2e tests.