### PR TITLE
ci: fix failing publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      pull-requests: read # Required for v6.0.0
     with:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}


### PR DESCRIPTION
I moved the workflows to v6 so e2e tests can run against the react19 dev preview image but didn't know it needed additional privileges. This PR should fix that.