### PR TITLE
chore: bump plugin-ci-workflows to ci-cd-workflows/v8.0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
   cd:
     name: CD
     needs: check-changelog
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     permissions:
       attestations: write
       contents: write

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.1
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Bumps `plugin-ci-workflows` from `ci-cd-workflows/v8.0.0` to `ci-cd-workflows/v8.0.1`.

**Changes in v8.0.1:**
- fix: install `jq` via apk in publish-docs step (docs-base is alpine)
- chore: bump `pnpm/action-setup` from v5.0.0 to v6.0.8